### PR TITLE
Move some File functionality to an intermediate Root class

### DIFF
--- a/nbtlib/nbt.py
+++ b/nbtlib/nbt.py
@@ -151,6 +151,4 @@ class File(Root):
         self.save()
 
     def __repr__(self):
-        if self.filename:
-            return f'<{self.__class__.__name__}({self.filename!r}): {self!r}>'
-        return super().__repr__(self)
+        return f'<{self.__class__.__name__} {self.root_name!r}: {self.root!r}>'

--- a/nbtlib/nbt.py
+++ b/nbtlib/nbt.py
@@ -2,11 +2,12 @@
 
 Exported items:
     load -- Helper function to load nbt files
-    File -- Class that represents an nbt file, inherits from `Compound`
+    Root -- Class that represents an nbt root tag, inherits from `Compound`
+    File -- Class that represents an nbt file, inherits from `Root`
 """
 
 
-__all__ = ['load', 'File']
+__all__ = ['load', 'Root', 'File']
 
 
 import gzip


### PR DESCRIPTION
As discussed in #1 :

Some NBT Compound tags are root tags but are not a file, namely Chunks from a Region File. As such it would be useful for them to have `.root` and `.root_name` but not `.load()`, `.save()`, etc.

This PR creates a `Root` class representing such compound tags, inheriting from `Compound`, move some of `File` functionality to this new class, and change `File` to inherit from `Root`