### PR TITLE
return the string itself in String.__str__(), without quotes or escaping

### DIFF
--- a/nbtlib/literal/serializer.py
+++ b/nbtlib/literal/serializer.py
@@ -132,7 +132,7 @@ class Serializer:
 
     def serialize_array(self, tag):
         """Return the literal representation of an array tag."""
-        elements = self.comma.join(map(str, tag)).upper()
+        elements = self.comma.join(map(serialize_tag, tag)).upper()
         return f'[{tag.array_prefix}{self.semicolon}{elements}]'
 
     def serialize_string(self, tag):

--- a/nbtlib/path.py
+++ b/nbtlib/path.py
@@ -278,4 +278,4 @@ class CompoundMatch(NamedTuple):
         return [(parent, tag) for parent, tag in tags if tag.match(self.compound)]
 
     def __str__(self):
-        return str(self.compound)
+        return self.compound.snbt()

--- a/nbtlib/tag.py
+++ b/nbtlib/tag.py
@@ -169,16 +169,13 @@ class Base:
             return False
         return self == other
 
+    def snbt(self):
+        return serialize_tag(self)
+
     def __repr__(self):
         if self.tag_id is not None:
             return f'{self.__class__.__name__}({super().__repr__()})'
         return super().__repr__()
-
-    def __str__(self):
-        try:
-            return serialize_tag(self)
-        except TypeError:
-            return super().__str__()
 
 
 class End(Base):
@@ -360,7 +357,7 @@ class Array(Base, np.ndarray):
         return all(self)
 
     def __repr__(self):
-        return f'{self.__class__.__name__}([{", ".join(int.__str__(el) for el in self)}])'
+        return f'{self.__class__.__name__}([{", ".join(map(str, self))}])'
 
 
 class ByteArray(Array):
@@ -386,9 +383,6 @@ class String(Base, str):
 
     def write(self, buff, byteorder='big'):
         write_string(self, buff, byteorder)
-
-    # String tags return their plain value on `str()`, not their snbt
-    __str__ = str.__str__
 
 
 class ListMeta(type):

--- a/nbtlib/tag.py
+++ b/nbtlib/tag.py
@@ -387,6 +387,9 @@ class String(Base, str):
     def write(self, buff, byteorder='big'):
         write_string(self, buff, byteorder)
 
+    def __str__(self):
+        return str.__str__(self)
+
 
 class ListMeta(type):
     """Allows class indexing to create and return subclasses on the fly.

--- a/nbtlib/tag.py
+++ b/nbtlib/tag.py
@@ -387,8 +387,8 @@ class String(Base, str):
     def write(self, buff, byteorder='big'):
         write_string(self, buff, byteorder)
 
-    def __str__(self):
-        return str.__str__(self)
+    # String tags return their plain value on `str()`, not their snbt
+    __str__ = str.__str__
 
 
 class ListMeta(type):

--- a/tests/test_literal.py
+++ b/tests/test_literal.py
@@ -12,12 +12,12 @@ def test_literal_parsing(literal, expected_tag):
 
 @pytest.mark.parametrize('literal, expected_tag', literal_values_for_tags)
 def test_tag_literal_value(literal, expected_tag):
-    assert str(parse_nbt(literal)) == str(expected_tag)
+    assert parse_nbt(literal).snbt() == expected_tag.snbt()
 
 
 @pytest.mark.parametrize('nbt_data', [nbt_data for _, nbt_data in nbt_files])
 def test_parsing_literal_tag_value(nbt_data):
-    assert str(parse_nbt(str(nbt_data))) == str(nbt_data)
+    assert parse_nbt(nbt_data.snbt()).snbt() == nbt_data.snbt()
 
 
 @pytest.mark.parametrize('literal', invalid_literals)


### PR DESCRIPTION
As discussed in #1 :

Currently `str(String('a')) == '"a"'`, as `String` does not declare `.__str__()` method and as such defaults to `Base.__str__()` which uses `serialize_tag()` for all tags.

While this default is convenient for all other tags, it is somewhat harmful to `String` as there's no trivial way to convert a string tag to a plain python string. In every usage of a string tag, be it `str(tag)`, `f"{tag}"`, `print(tag)`, `"{0}".format(tag)` or `"%s" % (tag,)`, it always add additional quotes and escapes. 

This leads to very interesting (and unfortunate) properties:
- `String('a') == 'a'`, but `str(String('a')) != str('a')` (With numeric tags we have `int(Int(1)) == int(1)`, same goes for `Float`)
- `String('a') != String(str(String('a'))`, every roundtrip adds additional more quotes and escapes
- `.__str__()`, and by proxy `str()`, is supposed to return the _plain string representation of a value_, which, in case of any string type, should be the (unquoted and un-escaped) string itself
- Currently there's no trivial way to obtain a `String` value as a plain python string.

This PR fixes this _without affecting other classes_. So `str(compound)` and `str(listtag) _still_ return their **snbt** representation, with `Strings` properly quoted and escaped, as their `serializer` directly runs `serialize_tag()` on each element.
