### PR TITLE
PEP 8 E501 compliance

### DIFF
--- a/examples/level_dat_bedrock.py
+++ b/examples/level_dat_bedrock.py
@@ -113,7 +113,10 @@ class BedrockLevelFile(File, CompoundSchema):
     def __init__(
         self, level_data=None, version=8, *, gzipped=False, byteorder="little"
     ):
-        super().__init__({"": level_data or {}}, gzipped=gzipped, byteorder=byteorder)
+        super().__init__(
+            {"": level_data or {}}, gzipped=gzipped, byteorder=byteorder
+        )
+
         self.version = version
 
     @classmethod

--- a/nbtlib/cli.py
+++ b/nbtlib/cli.py
@@ -21,7 +21,9 @@ def nbt_data(literal):
 
 # Create the argument parser
 
-parser = ArgumentParser(prog="nbt", description="Perform operations on nbt files.")
+parser = ArgumentParser(
+    prog="nbt", description="Perform operations on nbt files."
+)
 
 inputs = parser.add_mutually_exclusive_group()
 inputs.add_argument("-r", action="store_true", help="read nbt data from a file")
@@ -31,14 +33,27 @@ outputs = parser.add_mutually_exclusive_group()
 outputs.add_argument("-w", metavar="<nbt>", help="write nbt to a file")
 outputs.add_argument("-m", metavar="<nbt>", help="merge nbt into a file")
 
-parser.add_argument("--plain", action="store_true", help="don't use gzip compression")
-parser.add_argument("--little", action="store_true", help="use little-endian format")
-
-parser.add_argument("--compact", action="store_true", help="output compact snbt")
-parser.add_argument("--pretty", action="store_true", help="output indented snbt")
-parser.add_argument("--unpack", action="store_true", help="output interpreted nbt")
-parser.add_argument("--json", action="store_true", help="output nbt as json")
-parser.add_argument("--path", metavar="<path>", help="output all the matching tags")
+parser.add_argument(
+    "--plain", action="store_true", help="don't use gzip compression"
+)
+parser.add_argument(
+    "--little", action="store_true", help="use little-endian format"
+)
+parser.add_argument(
+    "--compact", action="store_true", help="output compact snbt"
+)
+parser.add_argument(
+    "--pretty", action="store_true", help="output indented snbt"
+)
+parser.add_argument(
+    "--unpack", action="store_true", help="output interpreted nbt"
+)
+parser.add_argument(
+    "--json", action="store_true", help="output nbt as json"
+)
+parser.add_argument(
+    "--path", metavar="<path>", help="output all the matching tags"
+)
 parser.add_argument(
     "--find", metavar="<path>", help="recursively find the first matching tag"
 )
@@ -59,16 +74,26 @@ def main():
             ):
                 if args.w:
                     write(tag, args.w, gzipped, byteorder)
+
                 elif args.m:
                     merge(tag, args.m, gzipped, byteorder)
+
                 else:
-                    display(tag, args.compact, args.pretty, args.unpack, args.json)
+                    display(
+                        tag, args.compact, args.pretty, args.unpack, args.json
+                    )
+
         elif args.w:
             write(nbt_data(args.w), args.file, gzipped, byteorder)
+
         elif args.m:
             merge(nbt_data(args.m), args.file, gzipped, byteorder)
+
         else:
-            parser.error("one of the following arguments is required: -r -s -w -m")
+            parser.error(
+                "one of the following arguments is required: -r -s -w -m"
+            )
+
     except (ArgumentTypeError, IOError) as exc:
         parser.error(f"{exc}")
 

--- a/nbtlib/contrib/minecraft/structure.py
+++ b/nbtlib/contrib/minecraft/structure.py
@@ -45,7 +45,9 @@ class StructureFile(File, CompoundSchema):
     strict = True
 
     def __init__(self, structure_data=None, *, filename=None):
-        super().__init__({"": structure_data or {}}, gzipped=True, filename=filename)
+        super().__init__(
+            {"": structure_data or {}}, gzipped=True, filename=filename
+        )
 
     @classmethod
     def load(cls, filename):

--- a/nbtlib/literal/parser.py
+++ b/nbtlib/literal/parser.py
@@ -45,7 +45,8 @@ TOKENS = {
     "QUOTED_STRING": "|".join(
         fr"{q}(?:{ESCAPE_REGEX.pattern}|[^\\])*?{q}" for q in STRING_QUOTES
     ),
-    "NUMBER": r"[+-]?(?:[0-9]*?\.[0-9]+|[0-9]+\.[0-9]*?|[1-9][0-9]*|0)([eE][+-]?[0-9]+)?[bslfdBSLFD]?(?![a-zA-Z0-9._+-])",
+    "NUMBER": r"[+-]?(?:[0-9]*?\.[0-9]+|[0-9]+\.[0-9]*?|[1-9][0-9]*|0)"
+              r"([eE][+-]?[0-9]+)?[bslfdBSLFD]?(?![a-zA-Z0-9._+-])",
     "STRING": r"[a-zA-Z0-9._+-]+",
     "COMPOUND": r"\{",
     "CLOSE_COMPOUND": r"\}",
@@ -203,7 +204,9 @@ class Parser:
                 return
 
             if self.current_token.type != "COMMA":
-                raise self.error(f"Expected comma but got {self.current_token.value!r}")
+                raise self.error(
+                    f"Expected comma but got {self.current_token.value!r}"
+                )
             self.next()
 
     def parse_compound(self):
@@ -219,7 +222,10 @@ class Parser:
                 item_key = self.unquote_string(item_key)
 
             if self.next().current_token.type != "COLON":
-                raise self.error(f"Expected colon but got {self.current_token.value!r}")
+                raise self.error(
+                    f"Expected colon but got {self.current_token.value!r}"
+                )
+
             self.next()
             compound_tag[item_key] = self.parse()
         return compound_tag
@@ -230,7 +236,10 @@ class Parser:
             is_number = token.type == "NUMBER"
             value = token.value.lower()
             if not (is_number and value.endswith(number_suffix)):
-                raise self.error(f"Invalid {number_type} array element {token.value!r}")
+                raise self.error(
+                    f"Invalid {number_type} array element {token.value!r}"
+                )
+
             yield int(value.replace(number_suffix, ""))
 
     def parse_byte_array(self):
@@ -249,8 +258,12 @@ class Parser:
         """Parse a list from the token stream."""
         try:
             return List(
-                [self.parse() for _ in self.collect_tokens_until("CLOSE_BRACKET")]
+                [
+                    self.parse()
+                    for _ in self.collect_tokens_until("CLOSE_BRACKET")
+                ]
             )
+
         except IncompatibleItemType as exc:
             raise self.error(
                 f"Item {str(exc.item)!r} is not a {exc.subtype.__name__} tag"

--- a/nbtlib/literal/serializer.py
+++ b/nbtlib/literal/serializer.py
@@ -113,7 +113,10 @@ class Serializer:
             quote = self.quote
         else:
             found = QUOTE_REGEX.search(string)
-            quote = STRING_QUOTES[found.group()] if found else next(iter(STRING_QUOTES))
+            quote = (
+                STRING_QUOTES[found.group()]
+                if found else next(iter(STRING_QUOTES))
+            )
 
         for match, seq in ESCAPE_SUBS.items():
             if match == quote or match not in STRING_QUOTES:
@@ -168,7 +171,8 @@ class Serializer:
 
             return fmt.format(
                 separator.join(
-                    f"{self.stringify_compound_key(key)}{self.colon}{self.serialize(value)}"
+                    f"{self.stringify_compound_key(key)}"
+                    f"{self.colon}{self.serialize(value)}"
                     for key, value in tag.items()
                 )
             )

--- a/nbtlib/literal/serializer.py
+++ b/nbtlib/literal/serializer.py
@@ -4,7 +4,8 @@ Exported functions:
     serialize_tag -- Helper function that serializes nbt tags
 
 Exported classes:
-    Serializer -- Class that can turn nbt tags into their literal representation
+    Serializer -- Class that can turn nbt tags into
+                    their literal representation
 
 Exported objects:
     STRING_QUOTES    -- Maps the two types of quote to each other
@@ -101,14 +102,16 @@ class Serializer:
         )
 
     def expand(self, separator, fmt):
-        """Return the expanded version of the separator and format string."""
+        """Return the expanded version
+            of the separator and format string."""
         return (
             f"{separator}\n{self.indent}",
             fmt.replace("{}", f"\n{self.indent}{{}}\n{self.previous_indent}"),
         )
 
     def escape_string(self, string):
-        """Return the escaped literal representation of an nbt string."""
+        """Return the escaped literal representation
+            of an nbt string."""
         if self.quote:
             quote = self.quote
         else:
@@ -125,7 +128,8 @@ class Serializer:
         return f"{quote}{string}{quote}"
 
     def stringify_compound_key(self, key):
-        """Escape the compound key if it can't be represented unquoted."""
+        """Escape the compound key
+            if it can't be represented unquoted."""
         if UNQUOTED_COMPOUND_KEY.match(key):
             return key
         return self.escape_string(key)

--- a/nbtlib/nbt.py
+++ b/nbtlib/nbt.py
@@ -327,12 +327,18 @@ class File(Root):
             >>> with demo:
             ...     demo.root['counter'] = nbtlib.Int(0)
 
-        This essentially overwrites the file at the end of the ``with`` statement.
+        This essentially overwrites the file at the end
+            of the ``with`` statement.
 
         Arguments:
-            filename: The name of the file. Defaults to the instance's :attr:`filename` attribute.
-            gzipped: Whether the file should be gzipped. Defaults to the instance's :attr:`gzipped` attribute.
-            byteorder: Whether the file should be big-endian or little-endian. Defaults to the instance's :attr:`byteorder` attribute.
+            filename: The name of the file.
+                Defaults to the instance's :attr:`filename` attribute.
+
+            gzipped: Whether the file should be gzipped.
+                Defaults to the instance's :attr:`gzipped` attribute.
+
+            byteorder: Whether the file should be big-endian or little-endian.
+                Defaults to the instance's :attr:`byteorder` attribute.
         """
         if gzipped is None:
             gzipped = self.gzipped
@@ -343,8 +349,8 @@ class File(Root):
             raise ValueError("No filename specified")
 
         open_file = gzip.open if gzipped else open
-        with open_file(filename, "wb") as fileobj:
-            self.write(fileobj, byteorder or self.byteorder)
+        with open_file(filename, "wb") as file_obj:
+            self.write(file_obj, byteorder or self.byteorder)
 
     def __enter__(self):
         return self

--- a/nbtlib/nbt.py
+++ b/nbtlib/nbt.py
@@ -15,17 +15,19 @@ You can load nbt files with the :func:`load` function.
     >>> nbtlib.load("docs/hello_world.nbt")
     <File 'hello world': Compound({...})>
 
-The function will figure out by itself if the file is gzipped before loading
-it. You can set the ``byteorder`` parameter to ``"little"`` if the file is
-little-endian.
+The function will figure out by itself if the file is gzipped before
+    loading it.
+
+You can set the ``byteorder`` parameter to ``"little"``
+    if the file is little-endian.
 
 .. doctest::
 
     >>> nbtlib.load("docs/hello_world_little.nbt", byteorder="little")
     <File 'hello world': Compound({...})>
 
-You can create new nbt files by instantiating the :class:`File` class with
-the desired nbt data and calling the :meth:`File.save` method.
+You can create new nbt files by instantiating the :class:`File` class
+with the desired nbt data and calling the :meth:`File.save` method.
 
 
 .. doctest::
@@ -70,10 +72,12 @@ def load(filename, *, gzipped=None, byteorder="big"):
         >>> nbt_file.root["stringTest"]
         String('HELLO WORLD THIS IS A TEST STRING ÅÄÖ!')
 
-    The function returns an instance of the dict-like :class:`File` class
-    holding all the data that could be parsed from the binary file.
-    You can retrieve items from the :attr:`Root.root` property with the index
-    operator just like with regular python dictionaries.
+    The function returns an instance of the dict-like :class:`File`
+    class holding all the data that could be parsed
+        from the binary file.
+
+    You can retrieve items from the :attr:`Root.root` property with the
+    index operator just like with regular python dictionaries.
 
     Note that the :class:`File` instance can be used as a context
     manager. The :meth:`File.save` method is called automatically at the
@@ -206,8 +210,8 @@ class File(Root):
         >>> nbt_file["Data"]
         Compound({'hello': String('world')})
 
-    You can write nbt data to an already opened file-like object with the
-    inherited :meth:`nbtlib.tag.Compound.write` method.
+    You can write nbt data to an already opened file-like object with
+    the inherited :meth:`nbtlib.tag.Compound.write` method.
 
     .. doctest::
 
@@ -216,8 +220,9 @@ class File(Root):
         >>> fileobj.getvalue()
         b'\n\x00\x04Data\x08\x00\x05hello\x00\x05world\x00'
 
-    If you need to load files from an already opened file-like object, you can
-    use the inherited :meth:`nbtlib.tag.Compound.parse` classmethod.
+    If you need to load files from an already opened file-like object,
+    you can use the inherited :meth:`nbtlib.tag.Compound.parse`
+    classmethod.
 
     .. doctest::
 
@@ -282,14 +287,17 @@ class File(Root):
             fileobj:
                 Can be either a standard ``io.BufferedReader`` for
                 uncompressed nbt or a ``gzip.GzipFile`` for gzipped nbt
-                data. The function simply calls the inherited
-                :meth:`nbtlib.tag.Compound.parse` classmethod and sets the
-                :attr:`filename` and :attr:`gzipped` attributes depending
-                on the argument.
+                data.
+
+                The function simply calls the inherited
+                :meth:`nbtlib.tag.Compound.parse` classmethod and sets
+                the :attr:`filename` and :attr:`gzipped` attributes
+                depending on the argument.
 
             byteorder:
-                Can be either ``"big"`` or ``"little"``. The argument is
-                forwarded to :meth:`nbtlib.tag.Compound.parse`.
+                Can be either ``"big"`` or ``"little"``.
+                The argument is  forwarded to
+                :meth:`nbtlib.tag.Compound.parse`.
         """
         self = cls.parse(fileobj, byteorder)
         self.filename = getattr(fileobj, "name", self.filename)
@@ -303,8 +311,8 @@ class File(Root):
 
         The method is used by the :func:`load` helper function when the
         ``gzipped`` keyword-only argument is specified explicitly.
-        The function opens the file and uses :meth:`from_fileobj` to return
-        the :class:`File` instance.
+        The function opens the file and uses :meth:`from_fileobj`
+        to return the :class:`File` instance.
 
         Arguments:
             filename: The name of the file.
@@ -337,7 +345,8 @@ class File(Root):
             gzipped: Whether the file should be gzipped.
                 Defaults to the instance's :attr:`gzipped` attribute.
 
-            byteorder: Whether the file should be big-endian or little-endian.
+            byteorder: Whether the file should be big-endian
+                or little-endian.
                 Defaults to the instance's :attr:`byteorder` attribute.
         """
         if gzipped is None:

--- a/nbtlib/path.py
+++ b/nbtlib/path.py
@@ -23,8 +23,8 @@ class InvalidPath(ValueError):
 class Path(tuple):
     """Represents an nbt path.
 
-    Instances of this class can be used for indexing into list and compound
-    tags for accessing deeply nested properties.
+    Instances of this class can be used for indexing into list
+    and compound tags for accessing deeply nested properties.
     """
 
     __slots__ = ()

--- a/nbtlib/schema.py
+++ b/nbtlib/schema.py
@@ -21,7 +21,7 @@ def schema(name, dct, *, strict=False):
     subclass the base `CompoundSchema` class.
 
     The `name` argument is the name of the class and `dct` should be a
-    dictionnary containing the actual schema. The schema should map keys
+    dictionary containing the actual schema. The schema should map keys
     to tag types or other compound schemas.
 
     If the `strict` keyword only argument is set to True, interacting
@@ -29,7 +29,9 @@ def schema(name, dct, *, strict=False):
     `TypeError`.
     """
     return type(
-        name, (CompoundSchema,), {"__slots__": (), "schema": dct, "strict": strict}
+        name,
+        (CompoundSchema,),
+        {"__slots__": (), "schema": dct, "strict": strict}
     )
 
 
@@ -67,7 +69,9 @@ class CompoundSchema(Compound):
 
     def update(self, mapping, **kwargs):
         pairs = chain(mapping.items(), kwargs.items())
-        super().update((key, self.cast_item(key, value)) for key, value in pairs)
+        super().update(
+            (key, self.cast_item(key, value)) for key, value in pairs
+        )
 
     def cast_item(self, key, value):
         """Cast schema item to the appropriate tag type."""

--- a/nbtlib/tag.py
+++ b/nbtlib/tag.py
@@ -23,29 +23,36 @@ objects using the :meth:`Base.write` method.
     >>> fileobj.getvalue()
     b'\x03\x00\x03foo\x00\x00\x00{\x00'
 
-Each tag inherits from a closely equivalent python builtin. For instance,
-the :class:`Compound` class inherits from the builtin ``dict`` type.
+Each tag inherits from a closely equivalent python builtin.
+For instance, the :class:`Compound` class inherits from the builtin
+``dict`` type.
+
 This means that all the familiar operations available on the base type
 work out of the box on the derived tag instances.
 
-+-------------------+---------------------------------------------------------+
-|     Base type     |                   Associated nbt tags                   |
-+===================+=========================================================+
-| ``int``           | :class:`Byte` :class:`Short` :class:`Int` :class:`Long` |
-+-------------------+---------------------------------------------------------+
-| ``float``         | :class:`Float` :class:`Double`                          |
-+-------------------+---------------------------------------------------------+
-| ``str``           | :class:`String`                                         |
-+-------------------+---------------------------------------------------------+
-| ``numpy.ndarray`` | :class:`ByteArray` :class:`IntArray` :class:`LongArray` |
-+-------------------+---------------------------------------------------------+
-| ``list``          | :class:`List`                                           |
-+-------------------+---------------------------------------------------------+
-| ``dict``          | :class:`Compound`                                       |
-+-------------------+---------------------------------------------------------+
++-------------------+--------------------------------------------------+
+|     Base type     |                   Associated nbt tags            |
++===================+==================================================+
+| ``int``           | :class:`Byte`                                    |
+|                   |  :class:`Short`                                  |
+|                   |  :class:`Int`                                    |
+|                   |  :class:`Long`                                   |
++-------------------+--------------------------------------------------+
+| ``float``         | :class:`Float` :class:`Double`                   |
++-------------------+--------------------------------------------------+
+| ``str``           | :class:`String`                                  |
++-------------------+--------------------------------------------------+
+| ``numpy.ndarray`` | :class:`ByteArray`                               |
+|                   | :class:`IntArray`                                |
+|                   | :class:`LongArray`                               |
++-------------------+--------------------------------------------------+
+| ``list``          | :class:`List`                                    |
++-------------------+--------------------------------------------------+
+| ``dict``          | :class:`Compound`                                |
++-------------------+--------------------------------------------------+
 
-Operator overloading works as expected with all tag types. Note that values are
-returned unwrapped.
+Operator overloading works as expected with all tag types.
+Note that values are returned unwrapped.
 
 .. doctest::
 
@@ -137,7 +144,8 @@ class OutOfRange(ValueError):
 
 
 class IncompatibleItemType(TypeError):
-    """Raised when a list item is incompatible with the subtype of the list.
+    """Raised when a list item is incompatible
+        with the subtype of the list.
 
     Unlike builtin python lists, list tags are homogeneous so adding an
     incompatible item to the list raises an error.
@@ -157,7 +165,8 @@ class IncompatibleItemType(TypeError):
 
 
 class CastError(ValueError):
-    """Raised when an object couldn't be converted to the appropriate tag type.
+    """Raised when an object couldn't be converted to
+        the appropriate tag type.
 
     Casting occurs when adding items to list tags and nbt schema
     instances. If the item couldn't be converted to the required type,
@@ -171,8 +180,11 @@ class CastError(ValueError):
         ...
         nbtlib.tag.CastError: Couldn't cast 'foo' to Int
 
-    Note that casting only occurs when the value is an unwrapped python object.
-    Incompatible tags will raise an :class:`IncompatibleItemType` exception.
+    Note that casting only occurs when the value is
+        an unwrapped python object.
+
+    Incompatible tags will raise
+        an :class:`IncompatibleItemType` exception.
 
     .. doctest::
 
@@ -321,14 +333,16 @@ class Base:
 
     @classmethod
     def parse(cls, fileobj, byteorder="big"):
-        r"""Parse data from a file-like object and return a tag instance.
+        r"""Parse data from a file-like object
+            and return a tag instance.
 
         The default implementation does nothing. Concrete tags override
         this method.
 
         Arguments:
             fileobj: A readable file-like object.
-            byteorder: Whether the nbt data is big-endian or little-endian.
+            byteorder: Whether the nbt data is big-endian
+                or little-endian.
 
             .. doctest::
 
@@ -341,7 +355,8 @@ class Base:
         """
 
     def write(self, fileobj, byteorder="big"):
-        r"""Write the binary representation of the tag to a file-like object.
+        r"""Write the binary representation
+            of the tag to a file-like object.
 
         The default implementation does nothing. Concrete tags override
         this method.
@@ -409,10 +424,11 @@ class Base:
             {'foo': 123}
 
         Arguments:
-            json: Whether the returned value should be json-serializable.
+            json:
+                Whether the returned value should be json-serializable.
 
-                This argument will convert array tags into plain python lists
-                instead of numpy arrays.
+                This argument will convert array tags into plain python
+                lists instead of numpy arrays.
 
                 .. doctest::
 
@@ -435,8 +451,10 @@ class End(Base):
     """Nbt tag used to mark the end of compound tags.
 
     :class:`End` tags are the markers that terminate compound tags in
-    the binary format. They need to exist as a type but can't be used on
-    their own so manual instantiation raises an :class:`EndInstantiation`
+    the binary format.
+
+    They need to exist as a type but can't be used on their own so
+        manual instantiation raises an :class:`EndInstantiation`
     exception.
 
     .. doctest::
@@ -657,8 +675,8 @@ class Array(Base, np.ndarray):
     :meth:`parse` and :meth:`write` depending on a few additional
     attributes.
 
-    Derived tags will use the ``array`` serializer and can specify an array
-    prefix with the :attr:`array_prefix` attribute.
+    Derived tags will use the ``array`` serializer and can specify
+        an array prefix with the :attr:`array_prefix` attribute.
 
     Attributes:
         item_type: The numpy array data type.
@@ -770,10 +788,11 @@ class String(Base, str):
 class List(Base, list):
     """Nbt tag representing a list of other nbt tags.
 
-    Nbt lists are homogeneous and can only hold a single type of tag. This
-    constraint is enforced by requiring the :class:`List` class to be
-    subclassed and define an appropriate :attr:`subtype` attribute. The
-    ``class_getitem`` operator is defined so that
+    Nbt lists are homogeneous and can only hold a single type of tag.
+    This constraint is enforced by requiring the :class:`List` class to
+    be subclassed and define an appropriate :attr:`subtype` attribute.
+
+    The ``class_getitem`` operator is defined so that
     ``List[TagName]`` returns a subclass with the subtype ``TagName``.
 
     .. doctest::
@@ -816,7 +835,8 @@ class List(Base, list):
         >>> strings
         List[String]([String('foo'), String('bar')])
 
-    However, note that impossible conversions raise a :class:`CastError`.
+    However,
+        note that impossible conversions raise a :class:`CastError`.
 
     .. doctest::
 
@@ -878,8 +898,9 @@ class List(Base, list):
             >>> List.infer_list_subtype([Int(123)])
             <class 'nbtlib.tag.Int'>
 
-        This method is used by the base :class:`List` constructor to figure
-        out the subtype of the :class:`List` subclass that should be returned.
+        This method is used by the base :class:`List` constructor to
+            figure out the subtype of the :class:`List` subclass
+            that should be returned.
 
         Arguments:
             items:
@@ -1053,8 +1074,10 @@ class List(Base, list):
 
         Arguments:
             item:
-                Can be any object convertible to the current tag type. If the
-                conversion fails, the method raises a :class:`CastError`.
+                Can be any object convertible to the current tag type.
+
+                If the conversion fails,
+                    the method raises a :class:`CastError`.
         """
         if not isinstance(item, cls.subtype):
             incompatible = isinstance(item, Base) and not any(
@@ -1166,7 +1189,9 @@ class Compound(Base, dict):
         """Get the element with the specified key.
 
         Arguments:
-            key: Can be a string or an instance of :class:`nbtlib.path.Path`.
+            key: Can be a string
+                or an instance of :class:`nbtlib.path.Path`.
+
             default: Returned when the element could not be found.
         """
         try:
@@ -1178,7 +1203,8 @@ class Compound(Base, dict):
         """Return all the elements matching the specified key.
 
         Arguments:
-            index: Can be a string or an instance of :class:`nbtlib.path.Path`.
+            index: Can be a string
+                or an instance of :class:`nbtlib.path.Path`.
         """
         try:
             return (
@@ -1226,7 +1252,11 @@ class Compound(Base, dict):
             ... })
             >>> compound["value"]
             Compound(
-                {'foo': Int(123), 'bar': Int(-1), 'hello': String('world')}
+                {
+                    'foo': Int(123),
+                    'bar': Int(-1),
+                    'hello': String('world')
+                }
             )
 
         Arguments:
@@ -1242,7 +1272,8 @@ class Compound(Base, dict):
                 self[key] = value
 
     def with_defaults(self, other):
-        """Return a new compound with recursively applied default values.
+        """Return a new compound
+            with recursively applied default values.
 
         .. doctest::
 
@@ -1254,7 +1285,11 @@ class Compound(Base, dict):
             ... })
             >>> new_compound["value"]
             Compound(
-                {'bar': Int(456), 'hello': String('world'), 'foo': Int(123)}
+                {
+                    'bar': Int(456),
+                    'hello': String('world'),
+                    'foo': Int(123)
+                }
             )
 
         Arguments:

--- a/nbtlib/tag.py
+++ b/nbtlib/tag.py
@@ -300,7 +300,7 @@ class Base:
     serializer = None
 
     def __init_subclass__(cls):
-        # Add class to the `all_tags` dictionnary if it has a tag id
+        # Add class to the `all_tags` dictionary if it has a tag id
         if cls.tag_id is not None and cls.tag_id not in cls.all_tags:
             cls.all_tags[cls.tag_id] = cls
 
@@ -314,7 +314,8 @@ class Base:
             <class 'nbtlib.tag.Int'>
 
         Arguments:
-            tag_id: The tag id must be valid otherwise the method raises a ``KeyError``.
+            tag_id: The tag id must be valid
+                otherwise the method raises a ``KeyError``.
         """
         return cls.all_tags[tag_id]
 
@@ -329,12 +330,14 @@ class Base:
             fileobj: A readable file-like object.
             byteorder: Whether the nbt data is big-endian or little-endian.
 
-                .. doctest::
+            .. doctest::
 
-                    >>> Int.parse(io.BytesIO(b"\x00\x00\x00\x01"))
-                    Int(1)
-                    >>> Int.parse(io.BytesIO(b"\x01\x00\x00\x00"), byteorder="little")
-                    Int(1)
+                >>> Int.parse(io.BytesIO(b"\x00\x00\x00\x01"))
+                Int(1)
+                >>> Int.parse(
+                >>>     io.BytesIO(b"\x01\x00\x00\x00"), byteorder="little"
+                >>> )
+                Int(1)
         """
 
     def write(self, fileobj, byteorder="big"):
@@ -345,7 +348,8 @@ class Base:
 
         Arguments:
             fileobj: A writable file-like object.
-            byteorder: Whether the nbt data should be big-endian or little-endian.
+            byteorder: Whether the nbt data should be big-endian
+                or little-endian.
 
                 .. doctest::
 
@@ -362,9 +366,9 @@ class Base:
     def match(self, other):
         """Check whether the tag recursively matches a subset of values.
 
-        The default implementation checks that the :attr:`tag_id` of the argument
-        matches and that the two instances are equal. Concrete tags override
-        this method.
+        The default implementation checks that the :attr:`tag_id` of the
+        argument matches and that the two instances are equal.
+        Concrete tags override this method.
 
         .. doctest::
 
@@ -396,7 +400,8 @@ class Base:
         return serialize_tag(self, indent=indent, compact=compact, quote=quote)
 
     def unpack(self, json=False):
-        """Return the unpacked nbt value as an instance of the associated base type.
+        """Return the unpacked nbt value as an instance
+            of the associated base type.
 
         .. doctest::
 
@@ -413,7 +418,9 @@ class Base:
 
                     >>> Compound({"foo": ByteArray([1, 2, 3])}).unpack()
                     {'foo': array([1, 2, 3], dtype=int8)}
-                    >>> Compound({"foo": ByteArray([1, 2, 3])}).unpack(json=True)
+                    >>> Compound(
+                    >>>     {"foo": ByteArray([1, 2, 3])}
+                    >>> ).unpack(json=True)
                     {'foo': [1, 2, 3]}
         """
         return None
@@ -698,13 +705,19 @@ class Array(Base, np.ndarray):
     def parse(cls, fileobj, byteorder="big"):
         """Override :meth:`Base.parse` for array tags."""
         item_type = cls.item_type[byteorder]
-        data = fileobj.read(read_numeric(INT, fileobj, byteorder) * item_type.itemsize)
+        data = fileobj.read(
+            read_numeric(INT, fileobj, byteorder) * item_type.itemsize
+        )
+
         return cls(np.frombuffer(data, item_type), byteorder=byteorder)
 
     def write(self, fileobj, byteorder="big"):
         """Override :meth:`Base.write` for array tags."""
         write_numeric(INT, len(self), fileobj, byteorder)
-        array = self if self.item_type[byteorder] is self.dtype else self.byteswap()
+        array = (
+            self if self.item_type[byteorder] is self.dtype else self.byteswap()
+        )
+
         fileobj.write(array.tobytes())
 
     def unpack(self, json=False):
@@ -849,7 +862,9 @@ class List(Base, list):
             return cls.variants[item]
         except KeyError:
             variant = type(
-                f"List[{item.__name__}]", (List,), {"__slots__": (), "subtype": item}
+                f"List[{item.__name__}]",
+                (List,),
+                {"__slots__": (), "subtype": item}
             )
             cls.variants[item] = variant
             return variant
@@ -930,7 +945,11 @@ class List(Base, list):
             return False
         if not other:
             return not self
-        return all(any(item.match(other_item) for item in self) for other_item in other)
+        return all(
+            any(
+                item.match(other_item) for item in self
+            ) for other_item in other
+        )
 
     def unpack(self, json=False):
         """Override :meth:`Base.unpack` for list tags."""
@@ -948,7 +967,9 @@ class List(Base, list):
             Int(42)
 
         Arguments:
-            index: Can be a string, an integer, a slice or an instance of :class:`nbtlib.path.Path`.
+            index: Can be a string, an integer,
+                a slice or an instance of :class:`nbtlib.path.Path`.
+
             default: Returned when the element could not be found.
         """
         value = find_tag(key, [self])
@@ -958,7 +979,9 @@ class List(Base, list):
         """Return the element at the specified index.
 
         Arguments:
-            index: Can be an integer, a slice or an instance of :class:`nbtlib.path.Path`.
+            index: Can be an integer,
+                a slice or an instance of :class:`nbtlib.path.Path`.
+
             default: Returned when the element could not be found.
         """
         return (self.get_all(index) or [default])[0]
@@ -967,7 +990,8 @@ class List(Base, list):
         """Return all the elements matching the specified index.
 
         Arguments:
-            index: Can be an integer, a slice or an instance of :class:`nbtlib.path.Path`.
+            index: Can be an integer,
+                a slice or an instance of :class:`nbtlib.path.Path`.
         """
         try:
             return (
@@ -1004,15 +1028,18 @@ class List(Base, list):
             index.delete(self)
 
     def append(self, value):
-        """Override ``list.append`` to include ``isinstance`` check and auto conversion."""
+        """Override ``list.append`` to include ``isinstance``
+            check and auto conversion."""
         super().append(self.cast_item(value))
 
     def extend(self, iterable):
-        """Override ``list.extend`` to include ``isinstance`` check and auto conversion."""
+        """Override ``list.extend`` to include ``isinstance``
+            check and auto conversion."""
         super().extend(map(self.cast_item, iterable))
 
     def insert(self, index, value):
-        """Override ``list.insert`` to include ``isinstance`` check and auto conversion."""
+        """Override ``list.insert`` to include ``isinstance``
+            check and auto conversion."""
         super().insert(index, self.cast_item(value))
 
     @classmethod
@@ -1128,7 +1155,8 @@ class Compound(Base, dict):
             Int(42)
 
         Arguments:
-            index: Can be a string, an integer, a slice or an instance of :class:`nbtlib.path.Path`.
+            index: Can be a string, an integer,
+                a slice or an instance of :class:`nbtlib.path.Path`.
             default: Returned when the element could not be found.
         """
         value = find_tag(key, [self])
@@ -1153,7 +1181,10 @@ class Compound(Base, dict):
             index: Can be a string or an instance of :class:`nbtlib.path.Path`.
         """
         try:
-            return [super().__getitem__(key)] if isinstance(key, str) else key.get(self)
+            return (
+                [super().__getitem__(key)]
+                if isinstance(key, str) else key.get(self)
+            )
         except KeyError:
             return []
 
@@ -1194,10 +1225,13 @@ class Compound(Base, dict):
             ...     "value": {"bar": Int(-1), "hello": String("world")},
             ... })
             >>> compound["value"]
-            Compound({'foo': Int(123), 'bar': Int(-1), 'hello': String('world')})
+            Compound(
+                {'foo': Int(123), 'bar': Int(-1), 'hello': String('world')}
+            )
 
         Arguments:
-            other: Can be a builtin ``dict`` or an instance of :class:`Compound`.
+            other: Can be a builtin ``dict``
+                or an instance of :class:`Compound`.
         """
         for key, value in other.items():
             if key in self and (
@@ -1219,10 +1253,13 @@ class Compound(Base, dict):
             ...     "value": {"bar": Int(-1), "hello": String("world")},
             ... })
             >>> new_compound["value"]
-            Compound({'bar': Int(456), 'hello': String('world'), 'foo': Int(123)})
+            Compound(
+                {'bar': Int(456), 'hello': String('world'), 'foo': Int(123)}
+            )
 
         Arguments:
-            other: Can be a builtin ``dict`` or an instance of :class:`Compound`.
+            other: Can be a builtin ``dict``
+                or an instance of :class:`Compound`.
         """
         result = Compound(other)
         for key, value in self.items():


### PR DESCRIPTION
Hi, I've implemented the `pep8 E501` rule into your project, 
including wrapping the code over `80` characters for better readability.
I also wrapped the docstring (excluding docstest) to 72 characters.

**Form Pep8** [Python official guide style](https://www.python.org/dev/peps/pep-0008/):

> Limit all lines to a maximum of 79 characters.
> For flowing long blocks of text with fewer structural restrictions (docstrings or comments), the line length should be limited to 72 characters.
>
> Limiting the required editor window width makes it possible to have several files open side by side, and works well when using code review tools that present the two versions in adjacent columns.
>
> The default wrapping in most tools disrupts the visual structure of the code, making it more difficult to understand. The limits are chosen to avoid wrapping in editors with the window width set to 80, even if the tool places a marker glyph in the final column when wrapping lines. Some web based tools may not offer dynamic line wrapping at all.
>
> Some teams strongly prefer a longer line length. For code maintained exclusively or primarily by a team that can reach agreement on this issue, it is okay to increase the line length limit up to 99 characters, provided that comments and docstrings are still wrapped at 72 characters.
>
> The Python standard library is conservative and requires limiting lines to 79 characters (and docstrings/comments to 72).
>
> The preferred way of wrapping long lines is by using Python's implied line continuation inside parentheses, brackets and braces.  Long lines can be broken over multiple lines by wrapping expressions in parentheses. These should be used in preference to using a backslash for line continuation.

*I took the time to also fix a minor typo (dictionnary => dictionary)*
Have a nice day !