### PR TITLE
Allow Path to concatenate with integers. Fix #146

### DIFF
--- a/nbtlib/path.py
+++ b/nbtlib/path.py
@@ -70,6 +70,8 @@ class Path(tuple):
             return self[other]
         elif isinstance(other, str):
             return self[Path(other)]
+        elif isinstance(other, int):
+            return self[other]
         else:
             return NotImplemented
 
@@ -78,6 +80,8 @@ class Path(tuple):
             return other[self]
         elif isinstance(other, str):
             return Path(other)[self]
+        elif isinstance(other, int):
+            return Path()[other][self]
         else:
             return NotImplemented
 


### PR DESCRIPTION
As an `int` can only represent a single index, we can use handle `P + int` the same way we handle `P[int]`:
`Path(...) + 1 == Path(...)[1]`
`1 + Path(...) == Path()[1][Path(...)]`

An alternate implementation would be to convert `1` to `"[1]"` and let it parse as a string.

Corresponding tests will be updated in the folowing commits.

The case for `Path(int)` is independent of this and is not addressed in this commit.