### PR TITLE
Allow integers to create and add with Path. Fix #146

### DIFF
--- a/nbtlib/path.py
+++ b/nbtlib/path.py
@@ -36,6 +36,10 @@ class Path(tuple):
         if isinstance(path, Path):
             return cls.from_accessors(path)
 
+        if isinstance(path, int):
+            # Handle an integer x as if the string "[x]" were just parsed
+            return cls.from_accessors((ListIndex(index=int(path)),))
+
         accessors = ()
         for accessor in parse_accessors(path):
             accessors = extend_accessors(accessors, accessor)
@@ -48,7 +52,7 @@ class Path(tuple):
         elif isinstance(key, str):
             new_accessors = (NamedKey(key),)
         elif isinstance(key, int):
-            new_accessors = (ListIndex(index=key),)
+            new_accessors = (ListIndex(index=int(key)),)
         elif isinstance(key, slice) and all(
             n is None for n in [key.start, key.stop, key.step]
         ):
@@ -68,7 +72,7 @@ class Path(tuple):
     def __add__(self, other):
         if isinstance(other, Path):
             return self[other]
-        elif isinstance(other, str):
+        elif isinstance(other, (str, int)):
             return self[Path(other)]
         else:
             return NotImplemented
@@ -76,7 +80,7 @@ class Path(tuple):
     def __radd__(self, other):
         if isinstance(other, Path):
             return other[self]
-        elif isinstance(other, str):
+        elif isinstance(other, (str, int)):
             return Path(other)[self]
         else:
             return NotImplemented


### PR DESCRIPTION
This effectively treats an integer `x` as if it were the string `"[x]"`, allowing
`Path(x)` and `x + Path(...) + x` in addition to current `Path(...)[x]`.

There are several possible implementation approaches, including a straightforward
`if isinstance(x, int): x = f"[{int(x)}]"` in `__new__`, `__add__` and `__radd__`,
then letting it parse as an actual string.

However, not only that approach is very inefficient, as it calls the parser and
tokenization for a known outcome, but also this was not the approach taken by
`__getitem__`, currently the only method that can be used as reference on how to
properly handle integers.

It is also important be consistent with the current _semantics_ of `Path(x)` and
`Path + x`, as they're different from `Path[x]` for strings and Paths, so do
not converge to using `Path[x]` for both. Even if for integers it ends up being
the same result, as integers can only be a single index, do not rely on that
and keep semantics distinct and consistent with the string code path.

So in `__new__`, instead of resorting to a `return cls()[x]` shortcut, we call the
same classmethod as str and Path do, `cls.from_accessors()`, passing the same
argument as __getitem__ uses: a tuple with a single element `ListIndex(index=x)`,
which is also, not coincidentally, the same result of parsing `"[x]"`.

As for `__add__`/`__radd__`, again we use the same semantics as used by str:
`Path(...) + x == Path(...)[Path(x)]`, and `x + Path(...) == Path(x)[Path(...)]`
And, as we just defined `Path(x)` for an integer x, we can simply extend the
`isinstance(x, str)` check to include `int`, without creating a new case, thus
enforcing consistent semantics.