### PR TITLE
fix: minor typos

### DIFF
--- a/nbtlib/schema.py
+++ b/nbtlib/schema.py
@@ -21,7 +21,7 @@ def schema(name, dct, *, strict=False):
     subclass the base `CompoundSchema` class.
 
     The `name` argument is the name of the class and `dct` should be a
-    dictionnary containing the actual schema. The schema should map keys
+    dictionary containing the actual schema. The schema should map keys
     to tag types or other compound schemas.
 
     If the `strict` keyword only argument is set to True, interacting
@@ -45,7 +45,7 @@ class CompoundSchema(Compound):
     predefined tag types for all of the inherited mutating operations.
 
     Class attributes:
-        schema -- Dictionnary mapping keys to tag types or other schemas
+        schema -- Dictionary mapping keys to tag types or other schemas
         strict -- Boolean enabling strict schema validation
     """
 

--- a/nbtlib/tag.py
+++ b/nbtlib/tag.py
@@ -257,7 +257,7 @@ class Base:
     :class:`Base` class and their associated builtin data type.
 
     Attributes:
-        all_tags: A dictionnary mapping tag ids to child classes.
+        all_tags: A dictionary mapping tag ids to child classes.
 
             .. doctest::
 
@@ -300,7 +300,7 @@ class Base:
     serializer = None
 
     def __init_subclass__(cls):
-        # Add class to the `all_tags` dictionnary if it has a tag id
+        # Add class to the `all_tags` dictionary if it has a tag id
         if cls.tag_id is not None and cls.tag_id not in cls.all_tags:
             cls.all_tags[cls.tag_id] = cls
 

--- a/nbtlib/tag.py
+++ b/nbtlib/tag.py
@@ -1098,7 +1098,7 @@ class Compound(Base, dict):
         """Override :meth:`Base.match` for compound tags.
 
         The method returns ``True`` if each key-value pair in the
-        dictionnary is present in the current instance.
+        dictionary is present in the current instance.
 
         .. doctest::
 
@@ -1183,7 +1183,7 @@ class Compound(Base, dict):
             key.delete(self)
 
     def merge(self, other):
-        """Recursively merge tags from another dictionnary.
+        """Recursively merge tags from another dictionary.
 
         .. doctest::
 


### PR DESCRIPTION
Re-submitting the only commit from #56 that is still worth merging: a fix of 2 small typos. One of them also spotted by @Sigmanificient in the rejected #138 . Those are _very_  resilient typos! :)