### PR TITLE
Make sure the trailing End tag is written to files. Fix #153

### DIFF
--- a/nbtlib/nbt.py
+++ b/nbtlib/nbt.py
@@ -208,10 +208,6 @@ class File(Compound):
                 'little'
     """
 
-    # We remove the inherited end tag as the end of nbt files is
-    # specified by the end of the file
-    end_tag = b""
-
     def __init__(
         self, *args, gzipped=False, byteorder="big", filename=None, root_name=""
     ):


### PR DESCRIPTION
This was automatically performed before by the extra `Compound` layer in `File`,
which was removed in e9180a2e042cdfd28c5ab1ccadaa14d05793dbb0

Now that `File` **is** the root tag itself, do not set `end_tag` to blank, let it
inherit the proper `b"\x00"` from `Compound`